### PR TITLE
Fix setting of Errbit host.

### DIFF
--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,9 +1,7 @@
 if ENV['ERRBIT_API_KEY'].present?
-  errbit_uri = Plek.find_uri('errbit')
-
   Airbrake.configure do |config|
     config.api_key = ENV['ERRBIT_API_KEY']
-    config.host = errbit_uri.host
+    config.host = "errbit.#{ENV['GOVUK_APP_DOMAIN']}"
     config.secure = errbit_uri.scheme == 'https'
     config.environment_name = ENV['ERRBIT_ENVIRONMENT_NAME']
   end


### PR DESCRIPTION
We can't use Plek for this because it needs to work on the draft frontends as well, and Plek gives `draft-errbit.<domain>` on those machines.
