### PR TITLE
Ensure slugs are well formed...

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   get "/foreign-travel-advice/:country_slug/print", variant: :print, to: "travel_advice#show", as: :travel_advice_country_print
   get "/foreign-travel-advice/:country_slug(/:part)", to: "travel_advice#show", as: :travel_advice_country
   get "/:slug/print", variant: :print, to: "multipage#show"
-  get "/:slug(/:part)", to: "multipage#show"
+  get "/:slug(/:part)", to: "multipage#show", constraints: { slug: /[\w_-]+/, format: :html }
 
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".

--- a/spec/features/show_multipage_spec.rb
+++ b/spec/features/show_multipage_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe "show multipage" do
+  let(:content_item) {{
+    "content_id": SecureRandom.uuid,
+    "base_path": "/vat-rates",
+    "title": "VAT rates",
+    "description": "Something about VAT",
+    "details": {
+      "updated_at": "2015-10-14T12:00:10+01:00",
+    }
+  }}
+  before do
+    content_store_has_item("/vat-rates", content_item)
+  end
+
+  scenario "requesting a path with an encoded slash" do
+    expect {
+      visit "/vat-rates%2F"
+    }.to raise_error(ActionController::RoutingError)
+  end
+
+  scenario "requesting atom format for multipage#show" do
+    expect {
+      visit "/vat-rates.atom"
+    }.to raise_error(ActionController::RoutingError)
+  end
+
+  scenario "requesting a valid path" do
+    visit "/vat-rates"
+    expect(page.status_code).to eq(200)
+  end
+end


### PR DESCRIPTION
[Errbit contains a large number of errors resulting from requests for
travel advice pages with an encoded forward slash in the url](https://errbit.publishing.service.gov.uk/apps/56937ef665786305d8f82200/problems/56b3456065786306f9101600). These
appear to come from bots like YandexBot and Yahoo! Slurp.
This change adds a constraint for the slug and format of the
`multipage#show` route.

It's open to discussion whether this is the right approach, the intent is to reduce noisy errors and serve 404 pages but any advice or comments welcome.
