### PR TITLE
Give HTML format priority over atom in respond_to

### DIFF
--- a/app/controllers/multipage_controller.rb
+++ b/app/controllers/multipage_controller.rb
@@ -18,8 +18,8 @@ class MultipageController < ApplicationController
     request.variant = :print if params[:variant].to_s == "print"
 
     respond_to do |format|
-      format.atom
       format.html.none
+      format.atom
       format.html.print do
         set_slimmer_headers template: "print"
         render layout: "application.print"

--- a/spec/features/show_travel_advice_country_spec.rb
+++ b/spec/features/show_travel_advice_country_spec.rb
@@ -194,4 +194,15 @@ describe "Viewing travel advice for albania" do
       ])
     end
   end
+
+  it "renders HTML when an unspecific accepts header is requested (eg by IE8 and below)" do
+    Capybara.current_session.driver.header('Accept', '*/*')
+    visit("/foreign-travel-advice/albania")
+
+    within(".page-navigation") do
+      expect(page).to have_content("Summary")
+      expect(page).to have_link("Part one")
+      expect(page).to have_link("Part two")
+    end
+  end
 end


### PR DESCRIPTION
If a browser sends an unspecific accepts header, eg `*/*`, Rails falls through to the first format/variant declared in `respond_to`.

Giving the HTML variant priority makes sure that gets rendered first. This was affecting IE8 and below.

Fixes #22
