### PR TITLE
Use analytics component

### DIFF
--- a/app/models/multipage.rb
+++ b/app/models/multipage.rb
@@ -1,7 +1,7 @@
 class Multipage
 
   attr_reader :current_part, :parts, :content_id, :base_path, :title,
-              :links, :description, :public_updated_at, :updated_at
+              :links, :description, :public_updated_at, :updated_at, :format
 
   def initialize(attrs, part_slug=nil)
     attrs = attrs.deep_symbolize_keys
@@ -10,6 +10,7 @@ class Multipage
     @title = attrs.fetch(:title)
     @description = attrs.fetch(:description)
     @links = attrs[:links]
+    @format = attrs.fetch(:format)
 
     if attrs[:public_updated_at]
       @public_updated_at = DateTime.parse(attrs[:public_updated_at])

--- a/app/presenters/multipage_presenter.rb
+++ b/app/presenters/multipage_presenter.rb
@@ -31,6 +31,10 @@ class MultipagePresenter
     RelatedLinksPresenter.new(related_links_data, ordered_breadcrumbs).present
   end
 
+  def format
+    content.format
+  end
+
 private
 
   def breadcrumbs_data

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
     <!--[if IE 7]><%= stylesheet_link_tag "application-ie7" %><![endif]-->
     <!--[if IE 8]><%= stylesheet_link_tag "application-ie8" %><![endif]-->
     <%= csrf_meta_tags %>
+    <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: {:format => @presenter.content.format } } %>
   </head>
   <body>
     <div id="wrapper">

--- a/spec/controllers/multipage_controller_spec.rb
+++ b/spec/controllers/multipage_controller_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe MultipageController, type: :controller do
         "title" => "Vat rates",
         "description" => "VAT rates for goods and services",
         "public_updated_at" => "2014-05-14T13:00:06.000+00:00",
-        "details" => details
+        "details" => details,
+        "format" => "foo",
       }
     end
 

--- a/spec/controllers/travel_advice_controller_spec.rb
+++ b/spec/controllers/travel_advice_controller_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe TravelAdviceController do
       "title" => "Albania travel advice",
       "description" => "Latest travel advice for Albania including safety and security, entry requirements, travel warnings and health",
       "public_updated_at" => "2014-01-01T00:00:00.000+00:00",
-      "details" => details
+      "details" => details,
+      "format" => "travel_advice",
     }
   end
 

--- a/spec/features/show_country_atom_feed_spec.rb
+++ b/spec/features/show_country_atom_feed_spec.rb
@@ -35,6 +35,7 @@ describe "Viewing atom feed for albania" do
       "description" => "Latest travel advice for Albania including safety and security, entry requirements, travel warnings and health",
       "details" => details,
       "public_updated_at" => "2014-05-14T13:00:06.000+00:00",
+      "format" => "travel_advice",
     }
   end
 

--- a/spec/features/show_print_travel_advice_country_spec.rb
+++ b/spec/features/show_print_travel_advice_country_spec.rb
@@ -34,7 +34,8 @@ describe "Viewing the print page for travel advice Albania" do
       "base_path" => "/foreign-travel-advice/albania",
       "title" => "Albania travel advice",
       "description" => "Latest travel advice for Albania including safety and security, entry requirements, travel warnings and health",
-      "details" => details
+      "details" => details,
+      "format" => "travel_advice",
     }
   end
 

--- a/spec/features/show_travel_advice_country_spec.rb
+++ b/spec/features/show_travel_advice_country_spec.rb
@@ -110,6 +110,10 @@ describe "Viewing travel advice for albania" do
     expect(api_path).to eq("/api/content/foreign-travel-advice/albania")
   end
 
+  it "passes the format to analytics" do
+    expect_analytics("content_item", {"format" => "travel_advice"})
+  end
+
   it "renders breadcrumbs" do
     expect_breadcrumbs([
       {

--- a/spec/features/show_travel_advice_country_spec.rb
+++ b/spec/features/show_travel_advice_country_spec.rb
@@ -96,6 +96,7 @@ describe "Viewing travel advice for albania" do
       "description" => "Latest travel advice for Albania including safety and security, entry requirements, travel warnings and health",
       "details" => details,
       "links" => links,
+      "format" => "travel_advice",
     }
   end
 

--- a/spec/models/multipage_spec.rb
+++ b/spec/models/multipage_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe Multipage do
         "content_id" => content_id,
         "public_updated_at" => "2015-10-15T11:00:20+01:00",
         "details" => details,
-        "links" => { "parent" => ["cf6c7d60-f28b-4f09-9549-458779aee7c3"] }
+        "links" => { "parent" => ["cf6c7d60-f28b-4f09-9549-458779aee7c3"] },
+        "format" => "foo",
       }
     end
     subject { described_class.new(attrs) }
@@ -36,6 +37,7 @@ RSpec.describe Multipage do
       expect(subject.description).to eq(attrs["description"])
       expect(subject.public_updated_at).to eq("2015-10-15T11:00:20+01:00")
       expect(subject.links).to eq(parent: ["cf6c7d60-f28b-4f09-9549-458779aee7c3"])
+      expect(subject.format).to eq(attrs["format"])
     end
 
     it "assigns parts" do

--- a/spec/models/travel_advice_spec.rb
+++ b/spec/models/travel_advice_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe TravelAdvice do
         "content_id" => content_id,
         "public_updated_at" => "2015-10-15T11:00:20+01:00",
         "details" => details,
+        "format" => "foo",
       }
     end
     subject { described_class.new(attrs) }

--- a/spec/support/govuk_component.rb
+++ b/spec/support/govuk_component.rb
@@ -21,6 +21,12 @@ module GovukComponent
     expect_component("related_items", "sections", value)
   end
 
+  def expect_analytics(key, value)
+    within shared_component_selector("analytics_meta_tags"), visible: false do
+      expect(JSON.parse(page.text(:all)).fetch(key)).to eq(value)
+    end
+  end
+
   def expect_govspeak(content)
     within shared_component_selector("govspeak") do
       expect(JSON.parse(page.text).fetch("content")).to eq(content)


### PR DESCRIPTION
Add usage of the [Analytics Component](https://github.com/alphagov/static/blob/7eea36767e31f77efc6140d94bbe0aaa04f2312a/app/views/govuk_component/analytics_meta_tags.raw.html.erb) to this app.

At the time of coding, the only relevant key we pass onto analytics is `format` - nothing else is currently offered by the formats represented here. So I'm constraining it to that key only.
