### PR TITLE
Set Atom `updated` to `public_updated_at`

### DIFF
--- a/app/views/travel_advice/_country.atom.builder
+++ b/app/views/travel_advice/_country.atom.builder
@@ -1,4 +1,4 @@
-feed.entry(country, id: "#{country.web_url}##{country.public_updated_at}", url: country.web_url) do |entry|
+feed.entry(country, id: "#{country.web_url}##{country.public_updated_at}", url: country.web_url, updated: country.public_updated_at) do |entry|
   entry.title(country.title)
   entry.link(:rel => "self", :type => "application/atom+xml", :href => "#{country.web_url}.atom")
   entry.summary(:type => :xhtml) do |summary|

--- a/spec/features/show_country_atom_feed_spec.rb
+++ b/spec/features/show_country_atom_feed_spec.rb
@@ -63,4 +63,9 @@ describe "Viewing atom feed for albania" do
     summary = page.find("//feed/entry/summary").text
     expect(summary).to eq("Something changed")
   end
+
+  it "sets the entry's updated correctly" do
+    updated = page.find("//feed/entry/updated").text
+    expect(updated).to eq("2014-05-14T13:00:06+00:00")
+  end
 end


### PR DESCRIPTION
By default this field "(d)efaults to the updated_at attribute on the
record if one such exists.":
http://api.rubyonrails.org/v3.2.2/classes/ActionView/Helpers/AtomFeedHelper/AtomFeedBuilder.html#method-i-entry

Explicitly set the value to `public_updated_at` in the constructor to
avoid this.
