### PR TITLE
Add format to attributes as this is required by model

### DIFF
--- a/spec/features/show_multipage_spec.rb
+++ b/spec/features/show_multipage_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe "show multipage" do
     "description": "Something about VAT",
     "details": {
       "updated_at": "2015-10-14T12:00:10+01:00",
-    }
+    },
+    "format": "guide",
   }}
   before do
     content_store_has_item("/vat-rates", content_item)


### PR DESCRIPTION
https://ci.dev.publishing.service.gov.uk/job/govuk_multipage-frontend/28/console is failing, [`format` is now required by the multipage model](https://github.com/alphagov/multipage-frontend/blob/master/app/models/multipage.rb#L12) so add this to the setup of `spec/features/show_multipage_spec.rb`
