### PR TITLE
Update specs to use the real email-signup url

### DIFF
--- a/spec/controllers/travel_advice_controller_spec.rb
+++ b/spec/controllers/travel_advice_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe TravelAdviceController do
       "summary" => "<p>Something about Albania</p>\n",
       "change_description" => "Something changed",
       "alert_status" => [],
-      "email_signup_link" => "https://public.govdelivery.com/accounts/UKGOVUK/subscriber/topics?qsp=TRAVEL",
+      "email_signup_link" => "/foreign-travel-advice/albania/email-signup",
       "updated_at" => "2015-10-14T12:00:10+01:00",
       "reviewed_at" => "2015-10-14T12:00:10+01:00",
       "parts" => [

--- a/spec/features/show_country_atom_feed_spec.rb
+++ b/spec/features/show_country_atom_feed_spec.rb
@@ -17,7 +17,7 @@ describe "Viewing atom feed for albania" do
       "summary" => "<p>Something about Albania</p>\n",
       "change_description" => "Something changed",
       "alert_status" => [],
-      "email_signup_link" => "https://public.govdelivery.com/accounts/UKGOVUK/subscriber/topics?qsp=TRAVEL",
+      "email_signup_link" => "/foreign-travel-advice/albania/email-signup",
       "updated_at" => "2015-10-14T12:00:10+01:00",
       "reviewed_at" => "2015-10-14T12:00:10+01:00",
       "parts" => [

--- a/spec/features/show_print_travel_advice_country_spec.rb
+++ b/spec/features/show_print_travel_advice_country_spec.rb
@@ -18,7 +18,7 @@ describe "Viewing the print page for travel advice Albania" do
       "public_updated_at" => "2014-05-14T13:00:06.000+00:00",
       "change_description" => "Something changed",
       "alert_status" => [],
-      "email_signup_link" => "https://public.govdelivery.com/accounts/UKGOVUK/subscriber/topics?qsp=TRAVEL",
+      "email_signup_link" => "/foreign-travel-advice/albania/email-signup",
       "updated_at" => "2015-10-14T12:00:10+01:00",
       "reviewed_at" => "2015-10-14T12:00:10+01:00",
       "parts" => [

--- a/spec/features/show_travel_advice_country_spec.rb
+++ b/spec/features/show_travel_advice_country_spec.rb
@@ -18,7 +18,7 @@ describe "Viewing travel advice for albania" do
       "public_updated_at" => "2014-05-14T13:00:06.000+00:00",
       "change_description" => "Something changed",
       "alert_status" => ["avoid_all_but_essential_travel_to_parts"],
-      "email_signup_link" => "https://public.govdelivery.com/accounts/UKGOVUK/subscriber/topics?qsp=TRAVEL",
+      "email_signup_link" => "/foreign-travel-advice/albania/email-signup",
       "updated_at" => "2015-10-14T12:00:10+01:00",
       "reviewed_at" => "2015-10-14T12:00:10+01:00",
       "parts" => [
@@ -163,7 +163,7 @@ describe "Viewing travel advice for albania" do
 
   it "renders the subscriptions info" do
     within(".subscriptions") do
-      expect(page).to have_link("email", href: "https://public.govdelivery.com/accounts/UKGOVUK/subscriber/topics?qsp=TRAVEL")
+      expect(page).to have_link("email", href: "/foreign-travel-advice/albania/email-signup")
       expect(page).to have_link("feed", href: "/foreign-travel-advice/albania.atom")
     end
   end

--- a/spec/models/travel_advice_spec.rb
+++ b/spec/models/travel_advice_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe TravelAdvice do
         "summary" => "The summary",
         "change_description" => "Something changed",
         "alert_status" => [],
-        "email_signup_link" => "https://public.govdelivery.com/accounts/UKGOVUK/subscriber/topics?qsp=TRAVEL",
+        "email_signup_link" => "/foreign-travel-advice/albania/email-signup",
         "updated_at" => "2015-10-14T12:00:10+01:00",
         "reviewed_at" => "2015-10-14T12:00:10+01:00",
         "parts" => [
@@ -51,7 +51,7 @@ RSpec.describe TravelAdvice do
       expect(subject.summary).to eq("The summary")
       expect(subject.change_description).to eq("Something changed")
       expect(subject.alert_status).to eq([])
-      expect(subject.email_signup_link).to eq("https://public.govdelivery.com/accounts/UKGOVUK/subscriber/topics?qsp=TRAVEL")
+      expect(subject.email_signup_link).to eq("/foreign-travel-advice/albania/email-signup")
       expect(subject.reviewed_at).to eq("2015-10-14T12:00:10+01:00")
     end
 


### PR DESCRIPTION
This doesn't change any implementation. It updates the tests to use representative URLs for the email-signup pages, rather than the old govdelivery URLs.
