### PR TITLE
Reduce cache time from 15.minutes to 10.seconds

### DIFF
--- a/app/controllers/travel_advice_controller.rb
+++ b/app/controllers/travel_advice_controller.rb
@@ -1,4 +1,9 @@
 class TravelAdviceController < MultipageController
+  def show
+    expires_in(10.seconds, public: true)
+    super
+  end
+
 private
 
   def base_path


### PR DESCRIPTION
If no cache control headers are set, the in-memory
cache in gds-api-adapters defaults to 15 minutes.
This is too long for travel advice. We could have
urgent updates that we need to send out, e.g. if
an act of terrorism has taken place.

https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api/json_client.rb

**This needs to be tested on staging – I will need help with this**

cc @danielroseman @steventux 
