### PR TITLE
Revert "Allow nil change-descriptions"

### DIFF
--- a/app/presenters/travel_advice_presenter.rb
+++ b/app/presenters/travel_advice_presenter.rb
@@ -45,7 +45,6 @@ class TravelAdvicePresenter < MultipagePresenter
   # has a latest update label, so we can strip this out.
   # Avoids: "Latest update: Latest update - …"
   def latest_update
-    return nil unless change_description.present?
     change_description.sub(/^Latest update:?\s-?\s?/i, '').tap do |latest|
       latest[0] = latest[0].capitalize
     end

--- a/app/views/travel_advice/_country_summary.html.erb
+++ b/app/views/travel_advice/_country_summary.html.erb
@@ -2,16 +2,13 @@
   <h1 class="part-content-title">Summary</h1>
 <% end %>
 
-<%
-  metadata = {
-    "Still current at" => Date.today.strftime("%e %B %Y"),
-    "Updated" => presenter.last_reviewed_or_updated_at.strftime("%e %B %Y"),
-  }
-
-  metadata["Latest update"] = simple_format(presenter.latest_update) if presenter.latest_update
+<%= render 'govuk_component/metadata',
+    other: {
+      "Still current at" => Date.today.strftime("%e %B %Y"),
+      "Updated" => presenter.last_reviewed_or_updated_at.strftime("%e %B %Y"),
+      "Latest update" => simple_format(presenter.latest_update)
+    }
 %>
-
-<%= render 'govuk_component/metadata', other: metadata %>
 
 <% if presenter.alert_status.present? %>
   <div class="help-notice">

--- a/spec/presenters/travel_advice_presenter_spec.rb
+++ b/spec/presenters/travel_advice_presenter_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe TravelAdvicePresenter do
         { original: "Latest update - changes", presented: "Changes" },
         { original: "Latest update changes", presented: "Changes" },
         { original: "Latest Update: Summary of changes. Next sentence", presented: "Summary of changes. Next sentence" },
-        { original: nil, presented: nil },
       ].each do |i|
         expect(present_latest(i[:original])).to eq(i[:presented])
       end


### PR DESCRIPTION
This reverts commit 397171499b8e38f337408d3cce3abab35a1395d6 (https://github.com/alphagov/multipage-frontend/pull/34).

The change was intended to be temporary. Change descriptions are a required field in the content schema and should never normally be nil.
- We don't ever want to display no "Latest update" message.
- This would mask the errors we were seeing yesterday
