### PR TITLE
Render publishing_request_id as a data-attribute...

### DIFF
--- a/app/models/multipage.rb
+++ b/app/models/multipage.rb
@@ -1,6 +1,7 @@
 class Multipage
   attr_reader :current_part, :parts, :content_id, :base_path, :title,
-              :links, :description, :public_updated_at, :updated_at, :format
+              :links, :description, :public_updated_at, :updated_at,
+              :format, :publishing_request_id
 
   def initialize(attrs, part_slug = nil)
     attrs = attrs.deep_symbolize_keys
@@ -17,6 +18,7 @@ class Multipage
 
     details = attrs.fetch(:details)
     @updated_at = DateTime.parse(details.fetch(:updated_at))
+    @publishing_request_id = details[:publishing_request_id]
     assign_parts(details)
     assign_current_part(part_slug)
   end

--- a/app/presenters/multipage_presenter.rb
+++ b/app/presenters/multipage_presenter.rb
@@ -35,6 +35,10 @@ class MultipagePresenter
     content.format
   end
 
+  def publishing_request_id
+    content.publishing_request_id
+  end
+
 private
 
   def breadcrumbs_data

--- a/app/views/travel_advice/show.html.erb
+++ b/app/views/travel_advice/show.html.erb
@@ -1,4 +1,7 @@
 <%= content_for :page_class, @presenter.content_class_dasherized %>
+<% content_for :extra_headers do %>
+  <meta name="govuk:publishing-request-id" content="<%= @presenter.publishing_request_id %>">
+<% end %>
 <%= render partial: 'govuk_component/breadcrumbs', locals: { breadcrumbs: @presenter.breadcrumbs } %>
 
 <div class="grid-row">

--- a/spec/features/show_travel_advice_country_spec.rb
+++ b/spec/features/show_travel_advice_country_spec.rb
@@ -24,7 +24,8 @@ describe "Viewing travel advice for albania" do
       "parts" => [
         { "title" => "Part one", "slug" => "part-one", "body" => "A new beginning" },
         { "title" => "Part two", "slug" => "part-two", "body" => "The next bit" },
-      ]
+      ],
+      "publishing_request_id": "76435-3285345345-345435345-4354"
     }
   end
 
@@ -212,5 +213,11 @@ describe "Viewing travel advice for albania" do
       expect(page).to have_link("Part one")
       expect(page).to have_link("Part two")
     end
+  end
+
+  it "renders the publishing_request_id as a data attribute" do
+    visit "/foreign-travel-advice/albania"
+
+    expect(page).to have_css("meta[name='govuk:publishing-request-id'][content='76435-3285345345-345435345-4354']", visible: false)
   end
 end


### PR DESCRIPTION
https://trello.com/c/Io2JYTFv/27-ensure-request-id-is-available-to-multipage-frontend-and-frontend-apps

In order to trace content updates thoroughly we'd like to have the id of the original publishing request somewhere in our rendered content, so this is added in a meta tag in the head of the document.
