### PR TITLE
Mitigate against broken parental heirarchy...

### DIFF
--- a/app/presenters/related_links_presenter.rb
+++ b/app/presenters/related_links_presenter.rb
@@ -29,7 +29,7 @@ private
 
     children.each do |child|
       parent = parents.find { |p| p[:content_id] == child[:links][:parent].first }
-      parent[:children] << child
+      parent[:children] << child if parent
     end
   end
 

--- a/spec/presenters/related_links_presenter_spec.rb
+++ b/spec/presenters/related_links_presenter_spec.rb
@@ -65,6 +65,26 @@ RSpec.describe RelatedLinksPresenter do
       end
     end
 
+    context "when parent links are incomplete" do
+      let(:related_links) {
+        content_item[:links][:related].reject { |i| i[:title] == "Travel abroad" }
+      }
+      it "excludes that parent" do
+        expect(subject.present).to eq([
+          {
+            title: "Passports, travel and living abroad",
+            url: "/browse/abroad",
+            items: [
+              {
+                title: "Renew or replace your adult passport",
+                url: "/renew-adult-passport"
+              }
+            ]
+          }
+        ])
+      end
+    end
+
     context "with no breadcrumbs data to use for ordering" do
       let(:breadcrumbs) { [] }
 


### PR DESCRIPTION
When encountering a 'broken' parental association in the related links hash
the RelatedLinksPresenter should omit child links orphaned by the broken association
and not raise an error as it does currently.
