### PR TITLE
Fix travel advice map image on small screen sizes

### DIFF
--- a/app/assets/stylesheets/views/_travel_advice.scss
+++ b/app/assets/stylesheets/views/_travel_advice.scss
@@ -141,6 +141,10 @@
     }
   }
 
+  .map-image {
+    max-width: 100%;
+  }
+
   .form-download {
     margin-top: $gutter;
     margin-bottom: $gutter;

--- a/app/views/travel_advice/_country_summary.html.erb
+++ b/app/views/travel_advice/_country_summary.html.erb
@@ -20,7 +20,7 @@
 
 <% if presenter.image %>
   <p>
-    <img src="<%= presenter.image.url %>" alt="" />
+    <img class="map-image" src="<%= presenter.image.url %>" alt="" />
   </p>
 <% end %>
 <% if presenter.document %>


### PR DESCRIPTION
The travel advice map wasn't being scaled down for small devices
and would overrun the side of the device, hiding content and causing
horizontal scrolling.

The image is scaled down slightly, but the PDF download link provides a full resolution version if more detail is needed.

| Before | After |
| --- | --- |
| ![ta-map-before](https://cloud.githubusercontent.com/assets/63201/16040058/4ee1b526-3225-11e6-8e46-4d310a119e89.png) | ![ta-map-after](https://cloud.githubusercontent.com/assets/63201/16040059/4ee3d22a-3225-11e6-9742-bcbd3fab6dd1.png) |

Live example reported by @amosie: https://www.gov.uk/foreign-travel-advice/egypt
