### PR TITLE
Add schema testing

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+export INITIATING_REPO_NAME="alphagov/govuk-content-schemas"
+export CONTEXT_MESSAGE="Verify multipage-frontend against content schemas"
+
+exec ./jenkins.sh


### PR DESCRIPTION
This application contains schema tests, but they're not run for PRs on alphagov/govuk-content-schemas.

This adds a jenkins shell script so they can be run by:

https://ci.dev.publishing.service.gov.uk/job/govuk_multipage_frontend_schema_tests

This issue surfaced because https://github.com/alphagov/govuk-content-schemas/pull/444 is passing while it shouldn't.

Trello: https://trello.com/c/C8A9bnuO