### PR TITLE
Copy jenkins.sh from known working version

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export INITIATING_REPO_NAME="alphagov/govuk-content-schemas"
+export REPO_NAME="alphagov/govuk-content-schemas"
 export CONTEXT_MESSAGE="Verify multipage-frontend against content schemas"
 
 exec ./jenkins.sh

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
+set -x
 
-GH_STATUS_REPO_NAME=${INITIATING_REPO_NAME:-"alphagov/multipage-frontend"}
+REPO_NAME=${REPO_NAME:-"alphagov/multipage-frontend"}
 CONTEXT_MESSAGE=${CONTEXT_MESSAGE:-"default"}
-GH_STATUS_GIT_COMMIT=${INITIATING_GIT_COMMIT:-${GIT_COMMIT}}
+GH_STATUS_GIT_COMMIT=${SCHEMA_GIT_COMMIT:-${GIT_COMMIT}}
+env
 
 function github_status {
-  STATUS="$1"
-  MESSAGE="$2"
-  gh-status "$GH_STATUS_REPO_NAME" "$GH_STATUS_GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" -c "$CONTEXT_MESSAGE" >/dev/null
+  REPO_NAME="$1"
+  STATUS="$2"
+  MESSAGE="$3"
+  gh-status "$REPO_NAME" "$GH_STATUS_GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" -c "$CONTEXT_MESSAGE" >/dev/null
 }
 
 function error_handler {
@@ -20,12 +23,12 @@ function error_handler {
   else
     echo "Error on or near line ${parent_lineno}; exiting with status ${code}"
   fi
-  github_status error "errored on Jenkins"
+  github_status "$REPO_NAME" error "errored on Jenkins"
   exit "${code}"
 }
 
 trap 'error_handler ${LINENO}' ERR
-github_status pending "is running on Jenkins"
+github_status "$REPO_NAME" pending "is running on Jenkins"
 
 # Cleanup anything left from previous test runs
 git clean -fdx
@@ -36,8 +39,13 @@ git clean -fdx
 git merge --no-commit origin/master || git merge --abort
 
 # Clone govuk-content-schemas depedency for contract tests
-rm -rf tmp/govuk-content-schemas
-git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
+rm -rf /tmp/govuk-content-schemas
+git clone git@github.com:alphagov/govuk-content-schemas.git /tmp/govuk-content-schemas
+(
+  cd /tmp/govuk-content-schemas
+  git checkout ${SCHEMA_GIT_COMMIT:-"deployed-to-production"}
+)
+export GOVUK_CONTENT_SCHEMAS_PATH=/tmp/govuk-content-schemas
 
 export RAILS_ENV=test
 bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --without development
@@ -52,13 +60,11 @@ if [[ ${GIT_BRANCH} != "origin/master" ]]; then
   bundle exec govuk-lint-sass app
 fi
 
-GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas bundle exec rake ${TEST_TASK:-"default"};
+bundle exec rake assets:precompile
 
-export EXIT_STATUS=$?
-
-if [ "$EXIT_STATUS" == "0" ]; then
-  github_status success "succeeded on Jenkins"
+if bundle exec rake ${TEST_TASK:-"default"}; then
+  github_status "$REPO_NAME" success "succeeded on Jenkins"
 else
-  github_status failure "failed on Jenkins"
+  github_status "$REPO_NAME" failure "failed on Jenkins"
   exit 1
 fi


### PR DESCRIPTION
I can't the schema tests for this repo to work. This copies the jenkins.sh and jenkins-schema.sh from alphagov/government-frontend. It works in that app so perhaps using the exact same thing here will fix our problems.

Trello: https://trello.com/c/C8A9bnuO