### PR TITLE
Use content item in analytics component

### DIFF
--- a/app/controllers/multipage_controller.rb
+++ b/app/controllers/multipage_controller.rb
@@ -4,7 +4,7 @@ class MultipageController < ApplicationController
   def show
     content_item_response = content_store.content_item(base_path)
     content = model_class.new(content_item_response.to_hash, params[:part]) if content_item_response
-
+    @content_item = content_item_response.to_hash
     @presenter = presenter_class.new(content, self)
 
     if params[:part] && !content.has_part?(params[:part])

--- a/app/models/multipage.rb
+++ b/app/models/multipage.rb
@@ -1,7 +1,7 @@
 class Multipage
   attr_reader :current_part, :parts, :content_id, :base_path, :title,
               :links, :description, :public_updated_at, :updated_at,
-              :format, :publishing_request_id
+              :publishing_request_id
 
   def initialize(attrs, part_slug = nil)
     attrs = attrs.deep_symbolize_keys
@@ -10,7 +10,6 @@ class Multipage
     @title = attrs.fetch(:title)
     @description = attrs.fetch(:description)
     @links = attrs[:links]
-    @format = attrs.fetch(:format)
 
     if attrs[:public_updated_at]
       @public_updated_at = DateTime.parse(attrs[:public_updated_at])

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,7 @@
     <!--[if IE 7]><%= stylesheet_link_tag "application-ie7" %><![endif]-->
     <!--[if IE 8]><%= stylesheet_link_tag "application-ie8" %><![endif]-->
     <%= csrf_meta_tags %>
-    <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: {:format => @presenter.content.format } } %>
+    <%= render partial: 'govuk_component/analytics_meta_tags', locals: { content_item: @content_item } %>
   </head>
   <body>
     <div id="wrapper">

--- a/spec/controllers/multipage_controller_spec.rb
+++ b/spec/controllers/multipage_controller_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe MultipageController, type: :controller do
         "description" => "VAT rates for goods and services",
         "public_updated_at" => "2014-05-14T13:00:06.000+00:00",
         "details" => details,
-        "format" => "foo",
       }
     end
 

--- a/spec/controllers/travel_advice_controller_spec.rb
+++ b/spec/controllers/travel_advice_controller_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe TravelAdviceController do
       "description" => "Latest travel advice for Albania including safety and security, entry requirements, travel warnings and health",
       "public_updated_at" => "2014-01-01T00:00:00.000+00:00",
       "details" => details,
-      "format" => "travel_advice",
     }
   end
 

--- a/spec/features/show_country_atom_feed_spec.rb
+++ b/spec/features/show_country_atom_feed_spec.rb
@@ -35,7 +35,6 @@ describe "Viewing atom feed for albania" do
       "description" => "Latest travel advice for Albania including safety and security, entry requirements, travel warnings and health",
       "details" => details,
       "public_updated_at" => "2014-05-14T13:00:06.000+00:00",
-      "format" => "travel_advice",
     }
   end
 

--- a/spec/features/show_multipage_spec.rb
+++ b/spec/features/show_multipage_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe "show multipage" do
     "details": {
       "updated_at": "2015-10-14T12:00:10+01:00",
     },
-    "format": "guide",
   }}
   before do
     content_store_has_item("/vat-rates", content_item)

--- a/spec/features/show_print_travel_advice_country_spec.rb
+++ b/spec/features/show_print_travel_advice_country_spec.rb
@@ -35,7 +35,6 @@ describe "Viewing the print page for travel advice Albania" do
       "title" => "Albania travel advice",
       "description" => "Latest travel advice for Albania including safety and security, entry requirements, travel warnings and health",
       "details" => details,
-      "format" => "travel_advice",
     }
   end
 

--- a/spec/features/show_travel_advice_country_spec.rb
+++ b/spec/features/show_travel_advice_country_spec.rb
@@ -97,7 +97,6 @@ describe "Viewing travel advice for albania" do
       "description" => "Latest travel advice for Albania including safety and security, entry requirements, travel warnings and health",
       "details" => details,
       "links" => links,
-      "format" => "travel_advice",
     }
   end
 
@@ -109,10 +108,6 @@ describe "Viewing travel advice for albania" do
   it "includes and API url for the content" do
     api_path = page.find("link[rel='alternate'][type='application/json']", visible: false)["href"]
     expect(api_path).to eq("/api/content/foreign-travel-advice/albania")
-  end
-
-  it "passes the format to analytics" do
-    expect_analytics("content_item", "format" => "travel_advice")
   end
 
   it "renders breadcrumbs" do

--- a/spec/models/multipage_spec.rb
+++ b/spec/models/multipage_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe Multipage do
         "public_updated_at" => "2015-10-15T11:00:20+01:00",
         "details" => details,
         "links" => { "parent" => ["cf6c7d60-f28b-4f09-9549-458779aee7c3"] },
-        "format" => "foo",
       }
     end
     subject { described_class.new(attrs) }
@@ -37,7 +36,6 @@ RSpec.describe Multipage do
       expect(subject.description).to eq(attrs["description"])
       expect(subject.public_updated_at).to eq("2015-10-15T11:00:20+01:00")
       expect(subject.links).to eq(parent: ["cf6c7d60-f28b-4f09-9549-458779aee7c3"])
-      expect(subject.format).to eq(attrs["format"])
     end
 
     it "assigns parts" do

--- a/spec/models/travel_advice_spec.rb
+++ b/spec/models/travel_advice_spec.rb
@@ -38,7 +38,6 @@ RSpec.describe TravelAdvice do
         "content_id" => content_id,
         "public_updated_at" => "2015-10-15T11:00:20+01:00",
         "details" => details,
-        "format" => "foo",
       }
     end
     subject { described_class.new(attrs) }

--- a/spec/support/govuk_component.rb
+++ b/spec/support/govuk_component.rb
@@ -22,12 +22,6 @@ module GovukComponent
     expect_component("related_items", value, "sections")
   end
 
-  def expect_analytics(key, value)
-    within shared_component_selector("analytics_meta_tags"), visible: false do
-      expect(JSON.parse(page.text(:all)).fetch(key)).to eq(value)
-    end
-  end
-
   def expect_govspeak(content)
     within shared_component_selector("govspeak") do
       expect(JSON.parse(page.text).fetch("content")).to eq(content)


### PR DESCRIPTION
The analytics component is currently only used to pass down `format`. We'd like to use the same analytics across GOV.UK. This commit makes sure that we use the component as we do in other applications.

By not using `format` explicitly anymore we can remove that field from the content store (https://github.com/alphagov/govuk-content-schemas/pull/444).

Trello: https://trello.com/c/C8A9bnuO