### PR TITLE
Bump slimmer to use Rails' cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem "govuk_frontend_toolkit", "2.0.1"
 gem "govuk_navigation_helpers", "2.1.0"
 gem "logstasher", "0.6.2"
 gem "plek", "1.11.0"
-gem "slimmer", "10.0.0"
+gem "slimmer", "~> 10.1.1"
 gem "unicorn", "5.0.1"
 gem "htmlentities"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,7 +222,7 @@ GEM
     simplecov-html (0.10.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    slimmer (10.0.0)
+    slimmer (10.1.1)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -290,7 +290,7 @@ DEPENDENCIES
   sdoc
   simplecov (= 0.10.0)
   simplecov-rcov (= 0.2.3)
-  slimmer (= 10.0.0)
+  slimmer (~> 10.1.1)
   uglifier (>= 1.3.0)
   unicorn (= 5.0.1)
   webmock (= 1.21.0)


### PR DESCRIPTION
This bumps slimmer to make it use the rails cache and send a user agent:

- https://github.com/alphagov/slimmer/pull/184
- https://github.com/alphagov/slimmer/pull/183

It will prevent this app from making many needless requests to `static`.

https://trello.com/c/D9HmkJwI